### PR TITLE
https://jira.rocketsoftware.com/browse/LS-20524 - [#LS-20524] Vertica…

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -841,7 +841,11 @@ qx.Class.define("qx.ui.table.pane.Scroller",
         var max = Math.max(0, scrollSize - paneSize.height);
 
         scrollBar.setMaximum(max);
-        scrollBar.setKnobFactor(paneSize.height / scrollSize);
+        if(scrollSize - paneSize.height < rowHeight) {
+          scrollBar.setKnobFactor(1);
+        } else {
+          scrollBar.setKnobFactor(paneSize.height / scrollSize);
+        }
 
         var pos = scrollBar.getPosition();
         scrollBar.setPosition(Math.min(pos, max));


### PR DESCRIPTION
…l grid scroll bar miscalculated

Make sure that when there is nothing to scroll, scrollbar knob would fill all slider
This can happen when vertical scrollbar is set to always