### PR TITLE
made sure that fix that qx team had for ios 7 is only applied for 7

### DIFF
--- a/framework/source/class/qx/bom/Viewport.js
+++ b/framework/source/class/qx/bom/Viewport.js
@@ -113,7 +113,7 @@ qx.Bootstrap.define("qx.bom.Viewport",
       var doc = win.document;
 
       // [BUG #7785] Document element's clientHeight is calculated wrong on iPad iOS7
-      if(qx.core.Environment.get("os.name") == "ios" && window.innerHeight != doc.documentElement.clientHeight) {
+      if(qx.core.Environment.get("os.name") === "ios" && qx.core.Environment.get("os.version").substring(0,1) === "7") {
         return window.innerHeight;
       }
 

--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -1640,7 +1640,9 @@ qx.Class.define("qx.ui.core.Widget",
 
       el.setAttribute("$$widget", this.toHashCode());
       //https://www.rocketrack.com/browse/LS-12796 - [#LS-12796] Web UI: Android tabled zoom and pan does not work right in DIS environment
-      el.setStyles({"touch-action": "auto", "-ms-touch-action" : "auto"});
+      //https://jira.rocketsoftware.com/browse/LS-21474 - [#LS-21474] LegaSuite Web does not pinch/zoom well when using iPhone in landscape mode
+      var touchAction = qx.core.Environment.get("os.name") === "ios" ? "manipulation" : "auto";
+      el.setStyles({"touch-action": touchAction, "-ms-touch-action" : touchAction});
 
       if (qx.core.Environment.get("qx.debug")) {
         el.setAttribute("qxClass", this.classname);


### PR DESCRIPTION
changed from touch action auto to manipulation for ios, as double tap to zoom does not work consistently anyway and it might improve ux related to tapping