### PR TITLE
`qx.ui.tabview.TabButton` does not conform to the API of superclass `…

### DIFF
--- a/source/class/qx/test/ui/basic/Atom.js
+++ b/source/class/qx/test/ui/basic/Atom.js
@@ -78,6 +78,43 @@ qx.Class.define("qx.test.ui.basic.Atom", {
       );
 
       a.destroy();
+    },
+
+    testLayoutOptionalProperties() {
+      let atomLayout;
+      const hasAtomLayout = new (qx.Class.define(null, {
+        extend: qx.ui.basic.Atom,
+        construct() {
+          super("test");
+          atomLayout = this._getLayout();
+        }
+      }))();
+
+      hasAtomLayout.setGap(10);
+      hasAtomLayout.setIconPosition("right");
+      hasAtomLayout.setCenter(true);
+
+      this.assertEquals(10, atomLayout.getGap());
+      this.assertEquals("right", atomLayout.getIconPosition());
+      this.assertEquals(true, atomLayout.getCenter());
+
+      const hasGridLayout = new (qx.Class.define(null, {
+        extend: qx.ui.basic.Atom,
+        construct() {
+          super("test");
+          this._getLayout().dispose();
+          this._setLayout(new qx.ui.layout.Grid());
+        }
+      }))();
+
+      // expect these to not throw an error (should log in debug env)
+      hasGridLayout.setGap(10);
+      hasGridLayout.setIconPosition("right");
+      hasGridLayout.setCenter(true);
+      // the values will be set to the Atom, they will not be set (or attempt to be set) on the layout of the Atom
+      this.assertEquals(10, hasGridLayout.getGap());
+      this.assertEquals("right", hasGridLayout.getIconPosition());
+      this.assertEquals(true, hasGridLayout.getCenter());
     }
   }
 });

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -277,24 +277,40 @@ qx.Class.define("qx.ui.basic.Atom", {
     },
 
     // property apply
-    _applyGap(value, old) {
-      this._getLayout().setGap(value);
-    },
-
-    // property apply
     _applyShow(value, old) {
       this._handleLabel();
       this._handleIcon();
     },
 
-    // property apply
-    _applyIconPosition(value, old) {
-      this._getLayout().setIconPosition(value);
+    __safeSetPropertyOnLayout(value, propertyName) {
+      const layout = this._getLayout();
+      const propertySetter = `set${qx.lang.String.firstUp(propertyName)}`;
+      if (layout[propertySetter]) {
+        layout[propertySetter](value);
+      } else if (qx.core.Environment.get("qx.debug")) {
+        this.warn(
+          `The \`${propertyName}\` property of a ${
+            this.classname
+          } was set, but the layout ${
+            this._getLayout().classname
+          } does not support a \`${propertyName}\` property.`
+        );
+      }
     },
 
     // property apply
-    _applyCenter(value, old) {
-      this._getLayout().setCenter(value);
+    _applyGap(value) {
+      this.__safeSetPropertyOnLayout(value, "gap");
+    },
+
+    // property apply
+    _applyIconPosition(value) {
+      this.__safeSetPropertyOnLayout(value, "iconPosition");
+    },
+
+    // property apply
+    _applyCenter(value) {
+      this.__safeSetPropertyOnLayout(value, "center");
     },
 
     // overridden


### PR DESCRIPTION
…qx.ui.basic.Atom` (#10642)

* fix issue with Atom public API assumptions
* quick fix; remove unwanted code
* lint: curlys around single-statement `if` clause
* extract common behavior to private method
* fix: **s**et, not get
* test properties in question
* tests: add assertions
* fix: remove dead code

Thanks @WillsterJohnsonAtZenesis !

(cherry picked from commit 09e33e03c4e72cfcd78340cb302996bb5a8d903d)